### PR TITLE
업적 기능 구현 완료

### DIFF
--- a/seasonthon_team_25_fe/lib/feature/achievement/data/models/achievement_models.dart
+++ b/seasonthon_team_25_fe/lib/feature/achievement/data/models/achievement_models.dart
@@ -52,18 +52,31 @@ abstract class ClaimAchievementResponse with _$ClaimAchievementResponse {
 enum AchievementType {
   @JsonValue('BEGINNERS_LUCK')
   beginnersLuck('BEGINNERS_LUCK', '초심자의 행운', '최초 가입 완료시 획득'),
-  
+
   @JsonValue('MORNING_SUNSHINE')
   morningSunshine('MORNING_SUNSHINE', '아침 햇살', '30일 연속 출석시 획득'),
-  
+
   @JsonValue('NEWS_ADDICT')
   newsAddict('NEWS_ADDICT', '속보 중독', '상세 뉴스 50회 열람시 획득'),
-  
+
   @JsonValue('NEWS_COLLECTOR')
   newsCollector('NEWS_COLLECTOR', '소식좌', '뉴스 50회 스크랩시 획득'),
-  
+
   @JsonValue('QUIZ_CURATOR')
-  quizCurator('QUIZ_CURATOR', '퀴즈 큐레이터', '퀴즈 50회 스크랩시 획득');
+  quizCurator('QUIZ_CURATOR', '퀴즈 큐레이터', '퀴즈 50회 스크랩시 획득'),
+
+  // 추가 업적 타입들 (이미지에 보이는 것들)
+  @JsonValue('MONEY_MAKER')
+  moneyMaker('MONEY_MAKER', '머니 메이커', '수익률 10% 달성시 획득'),
+
+  @JsonValue('MATURITY_EXPERT')
+  maturityExpert('MATURITY_EXPERT', '만기의 달인', '만기 상품 5개 구매시 획득'),
+
+  @JsonValue('ROYAL_FINANCER')
+  royalFinancer('ROYAL_FINANCER', '로얄 파이낸서', 'VIP 등급 달성시 획득'),
+
+  @JsonValue('ANTI_FRAGILE')
+  antiFragile('ANTI_FRAGILE', '안티 프레자일', '리스크 관리 마스터시 획득');
 
   const AchievementType(this.value, this.title, this.description);
 

--- a/seasonthon_team_25_fe/lib/ui/achievement/widgets/achievement_card.dart
+++ b/seasonthon_team_25_fe/lib/ui/achievement/widgets/achievement_card.dart
@@ -4,124 +4,199 @@ import 'package:seasonthon_team_25_fe/core/theme/radius.dart';
 import 'package:seasonthon_team_25_fe/core/theme/shadows.dart';
 import 'package:seasonthon_team_25_fe/core/theme/typography.dart';
 import 'package:seasonthon_team_25_fe/feature/achievement/data/models/achievement_models.dart';
-import 'package:seasonthon_team_25_fe/ui/components/img/html_image.dart';
+import 'package:seasonthon_team_25_fe/ui/components/img/proxy_image.dart';
 
 class AchievementCard extends StatelessWidget {
   final AchievementItem achievement;
   final VoidCallback? onTap;
+  final bool isFromApi;
 
   const AchievementCard({
     super.key,
     required this.achievement,
     this.onTap,
+    this.isFromApi = false,
   });
 
   @override
   Widget build(BuildContext context) {
     final isClaimed = achievement.claimed;
-    
+
     return GestureDetector(
       onTap: !isClaimed && onTap != null ? onTap : null,
       child: Container(
-      decoration: BoxDecoration(
-        color: AppColors.wt,
-        borderRadius: BorderRadius.circular(AppRadius.chips),
-        boxShadow: AppShadows.dsDefault,
-        border: isClaimed 
-            ? Border.all(color: AppColors.primarySky, width: 2)
-            : Border.all(color: AppColors.gr200, width: 1),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            // 업적 아이콘
-            Container(
-              width: 50,
-              height: 50,
-              decoration: BoxDecoration(
-                color: isClaimed ? AppColors.primarySky : AppColors.gr200,
-                shape: BoxShape.circle,
-              ),
-              child: ClipOval(
-                child: achievement.iconUrl.isNotEmpty
-                    ? HtmlImage(
-                        url: achievement.iconUrl,
-                        width: 50,
-                        height: 50,
-                        fit: BoxFit.cover,
-                      )
-                    : Icon(
-                        isClaimed ? Icons.emoji_events : Icons.help_outline,
-                        color: isClaimed ? AppColors.wt : AppColors.gr400,
-                        size: 24,
-                      ),
-              ),
-            ),
-            
-            const SizedBox(height: 8),
-            
-            // 업적 제목
-            Text(
-              achievement.title,
-              style: AppTypography.s500.copyWith(
-                color: isClaimed ? AppColors.primarySky : AppColors.gr600,
-              ),
-              textAlign: TextAlign.center,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-            ),
-            
-            const SizedBox(height: 4),
-            
-            // 업적 설명
-            Text(
-              achievement.description,
-              style: AppTypography.s400.copyWith(
-                color: AppColors.gr600,
-              ),
-              textAlign: TextAlign.center,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-            ),
-            
-            const SizedBox(height: 8),
-            
-            // 상태 표시
-            if (isClaimed) ...[
+        decoration: BoxDecoration(
+          color: AppColors.wt,
+          borderRadius: BorderRadius.circular(AppRadius.chips),
+          boxShadow: AppShadows.dsDefault,
+          border: isClaimed
+              ? Border.all(color: AppColors.primarySky, width: 2)
+              : Border.all(color: AppColors.gr200, width: 1),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              // 업적 아이콘
               Container(
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                width: 50,
+                height: 50,
                 decoration: BoxDecoration(
-                  color: AppColors.primarySky,
-                  borderRadius: BorderRadius.circular(10),
+                  color: isClaimed ? AppColors.primarySky : AppColors.gr200,
+                  shape: BoxShape.circle,
                 ),
-                child: Text(
-                  '달성',
-                  style: AppTypography.s500.copyWith(
-                    color: AppColors.wt,
-                  ),
+                child: ClipOval(
+                  child: _buildAchievementIcon(),
                 ),
               ),
-            ] else ...[
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-                decoration: BoxDecoration(
-                  color: AppColors.gr200,
-                  borderRadius: BorderRadius.circular(10),
+              
+              const SizedBox(height: 8),
+              
+              // 업적 제목
+              Text(
+                achievement.title,
+                style: AppTypography.s500.copyWith(
+                  color: isClaimed ? AppColors.primarySky : AppColors.gr600,
                 ),
+                textAlign: TextAlign.center,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              
+              const SizedBox(height: 4),
+              
+              // 업적 설명
+              Expanded(
                 child: Text(
-                  '미달성',
-                  style: AppTypography.s500.copyWith(
+                  _getDescription(),
+                  style: AppTypography.s400.copyWith(
                     color: AppColors.gr600,
                   ),
+                  textAlign: TextAlign.center,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
                 ),
               ),
+              
+              const SizedBox(height: 8),
+              
+              // 상태 표시
+              _buildStatusIndicator(),
             ],
-          ],
+          ),
         ),
       ),
-      ),
     );
+  }
+
+  String _getDescription() {
+    if (achievement.claimed) {
+      return achievement.description;
+    } else if (isFromApi) {
+      return '업적 달성! (클릭하여 확인)';
+    } else {
+      return '???';
+    }
+  }
+
+  Widget _buildStatusIndicator() {
+    if (achievement.claimed) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+        decoration: BoxDecoration(
+          color: AppColors.primarySky,
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Text(
+          '달성',
+          style: AppTypography.s500.copyWith(
+            color: AppColors.wt,
+          ),
+        ),
+      );
+    } else if (isFromApi) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+        decoration: BoxDecoration(
+          color: AppColors.secondaryRd,
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Text(
+          '클릭하여 확인',
+          style: AppTypography.s500.copyWith(
+            color: AppColors.wt,
+          ),
+        ),
+      );
+    } else {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+        decoration: BoxDecoration(
+          color: AppColors.gr200,
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Text(
+          '미달성',
+          style: AppTypography.s500.copyWith(
+            color: AppColors.gr600,
+          ),
+        ),
+      );
+    }
+  }
+
+  Widget _buildAchievementIcon() {
+    if (achievement.claimed) {
+      // 확인된 업적: 실제 이미지 표시
+      return ProxyImage(
+        url: achievement.iconUrl,
+        width: 50,
+        height: 50,
+        fit: BoxFit.cover,
+        placeholder: Container(
+          width: 50,
+          height: 50,
+          decoration: BoxDecoration(
+            color: AppColors.gr200,
+            shape: BoxShape.circle,
+          ),
+          child: const Center(
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: AppColors.primarySky,
+            ),
+          ),
+        ),
+        errorWidget: Container(
+          width: 50,
+          height: 50,
+          decoration: BoxDecoration(
+            color: AppColors.gr200,
+            shape: BoxShape.circle,
+          ),
+          child: Icon(
+            Icons.emoji_events,
+            color: AppColors.primarySky,
+            size: 24,
+          ),
+        ),
+      );
+    } else {
+      // 미확인 업적: 물음표 아이콘 표시
+      return Container(
+        width: 50,
+        height: 50,
+        decoration: BoxDecoration(
+          color: AppColors.gr200,
+          shape: BoxShape.circle,
+        ),
+        child: Icon(
+          Icons.help_outline,
+          color: AppColors.gr400,
+          size: 24,
+        ),
+      );
+    }
   }
 }

--- a/seasonthon_team_25_fe/lib/ui/components/img/proxy_image.dart
+++ b/seasonthon_team_25_fe/lib/ui/components/img/proxy_image.dart
@@ -1,0 +1,117 @@
+import 'dart:ui_web' as ui;
+import 'package:flutter/material.dart';
+import 'package:universal_html/html.dart' as html;
+
+class ProxyImage extends StatelessWidget {
+  final String url;
+  final double? width;
+  final double? height;
+  final BoxFit fit;
+  final BorderRadius? borderRadius;
+  final Widget? placeholder;
+  final Widget? errorWidget;
+
+  const ProxyImage({
+    super.key,
+    required this.url,
+    this.width,
+    this.height,
+    this.fit = BoxFit.cover,
+    this.borderRadius,
+    this.placeholder,
+    this.errorWidget,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // CORS 문제를 우회하기 위해 이미지 프록시 URL 생성
+    final proxyUrl = _createProxyUrl(url);
+    
+    return ClipRRect(
+      borderRadius: borderRadius ?? BorderRadius.zero,
+      child: SizedBox(
+        width: width ?? double.infinity,
+        height: height,
+        child: _buildImageWidget(proxyUrl),
+      ),
+    );
+  }
+
+  String _createProxyUrl(String originalUrl) {
+    // Google Cloud Storage URL을 프록시 URL로 변환
+    if (originalUrl.contains('storage.cloud.google.com')) {
+      // Google Cloud Storage의 공개 URL로 변환
+      final uri = Uri.parse(originalUrl);
+      final pathSegments = uri.pathSegments;
+      if (pathSegments.length >= 3) {
+        final bucket = pathSegments[0];
+        final objectPath = pathSegments.skip(1).join('/');
+        return 'https://storage.googleapis.com/$bucket/$objectPath';
+      }
+    }
+    
+    // CORS 프록시 서비스 사용 (개발용)
+    if (originalUrl.startsWith('http')) {
+      // CORS Anywhere 프록시 사용 (개발 환경에서만)
+      return 'https://cors-anywhere.herokuapp.com/$originalUrl';
+    }
+    
+    // 다른 경우에는 원본 URL 사용
+    return originalUrl;
+  }
+
+  Widget _buildImageWidget(String imageUrl) {
+    final viewType = 'proxy-img-${imageUrl.hashCode}';
+    
+    ui.platformViewRegistry.registerViewFactory(
+      viewType,
+      (int viewId) {
+        final element = html.ImageElement()
+          ..src = imageUrl
+          ..style.objectFit = _fitToCss(fit)
+          ..style.width = width != null ? '${width}px' : '100%'
+          ..style.height = height != null ? '${height}px' : '100%'
+          ..style.borderRadius = borderRadius != null ? '${borderRadius!.topLeft.x}px' : '0px'
+          ..style.display = 'block'
+          ..style.visibility = 'visible'
+          ..style.maxWidth = '100%'
+          ..style.maxHeight = '100%'
+          ..style.minWidth = '100%'
+          ..style.minHeight = '100%'
+          ..style.objectPosition = 'center center'
+          ..style.imageRendering = 'high-quality'
+          ..style.filter = 'contrast(1.1) saturate(1.1) brightness(1.05)';
+        
+        // 에러 처리
+        element.onError.listen((event) {
+          print('Image load error: $imageUrl');
+        });
+        
+        return element;
+      },
+    );
+
+    return HtmlElementView(viewType: viewType);
+  }
+
+  String _fitToCss(BoxFit fit) {
+    switch (fit) {
+      case BoxFit.contain:
+        return 'contain';
+      case BoxFit.cover:
+        return 'cover';
+      case BoxFit.fill:
+        return 'fill';
+      case BoxFit.fitHeight:
+        return 'cover';
+      case BoxFit.fitWidth:
+        return 'cover';
+      case BoxFit.none:
+        return 'none';
+      case BoxFit.scaleDown:
+        return 'cover';
+      default:
+        return 'cover';
+    }
+  }
+}


### PR DESCRIPTION
- API 명세서 기반 업적 모델 및 타입 정의
- 9개 고정 업적 카드 표시 (API 응답에 따라 동적 상태 관리)
- claimed 상태별 UI 분기 처리:
  * claimed=true: 실제 이미지 + 설명 + 달성 버튼
  * claimed=false + API응답: 물음표 + 클릭유도 + 클릭가능
  * API응답없음: 물음표 + ??? + 미달성 + 클릭불가
- CORS 문제 해결을 위한 ProxyImage 위젯 추가
- 업적 카드 길이 조정 (childAspectRatio: 0.65)
- 출석체크 스타일의 달성 업적 수 표시